### PR TITLE
Convert folder checks to string in file management

### DIFF
--- a/scripts/civitai_file_manage.py
+++ b/scripts/civitai_file_manage.py
@@ -871,7 +871,7 @@ def _detect_content_type_from_path(file_path):
         _api.contenttype_folder('Upscaler', 'ESRGAN')
     ]
     for folder in upscaler_folders:
-        if folder and file_path.startswith(folder):
+        if folder and file_path.startswith(str(folder)):
             return 'Upscaler'
 
     content_types = [
@@ -880,7 +880,7 @@ def _detect_content_type_from_path(file_path):
     ]
     for content_type in content_types:
         folder = _api.contenttype_folder(content_type)
-        if folder and file_path.startswith(folder):
+        if folder and file_path.startswith(str(folder)):
             return content_type
 
     return 'Other'


### PR DESCRIPTION
Fixes the error (in versions of WebUI Forge Neo as of 2026-05-23): 

```
File "D:\StabilityMatrix\Data\Packages\forge-neo\extensions\sd-civitai-browser-neo\scripts\civitai_file_manage.py", line 883, in _detect_content_type_from_path
    if folder and file_path.startswith(folder):
                  ~~~~~~~~~~~~~~~~~~~~^^^^^^^^
TypeError: startswith first arg must be str or a tuple of str, not WindowsPath 
```

Tested locally in my WebUI Forge Neo installation (via StabilityMatrix on Windows)