### PR TITLE
fix(paths): handle Forge Neo append-list directory args (--lora-dirs / --ckpt-dirs)

### DIFF
--- a/scripts/civitai_api.py
+++ b/scripts/civitai_api.py
@@ -339,9 +339,17 @@ def contenttype_folder(content_type, desc=None, custom_folder=None):
     ext_dir     = Path(extensions_dir)                                          # Extensions directory path
 
     def resolve_path(attr, fallback):
-        # Returns a Path from cmd_opts if set, otherwise fallback
-        if getattr(cmd_opts, attr, None) and not custom_folder:
-            return Path(getattr(cmd_opts, attr))
+        # Returns a Path from cmd_opts if set, otherwise fallback.
+        # Forge Neo's directory args (--ckpt-dirs, --lora-dirs, --text-encoder-dirs)
+        # use argparse action="append", so they arrive as lists rather than strings.
+        # Take the first entry — Path() raises TypeError when handed a list.
+        # Their default is [], which is falsy, so unset args still hit the fallback.
+        value = getattr(cmd_opts, attr, None)
+        if value and not custom_folder:
+            if isinstance(value, (list, tuple)):
+                value = value[0] if value else None
+            if value:
+                return Path(value)
         return fallback
 
     # Mapping for content types
@@ -350,9 +358,9 @@ def contenttype_folder(content_type, desc=None, custom_folder=None):
         'Checkpoint': lambda: resolve_path('ckpt_dir', resolve_path('ckpt_dirs', main_models / 'Stable-diffusion')),
         'TextualInversion': lambda: resolve_path('embeddings_dir', _resolve_embeddings_folder(main_models, main_data)),
         'AestheticGradient': lambda: (Path(custom_folder) if custom_folder else ext_dir / 'stable-diffusion-webui-aesthetic-gradients') / 'aesthetic_embeddings',
-        'LORA': lambda: resolve_path('lora_dir', main_models / 'Lora'),
-        'LoCon': lambda: resolve_path('lora_dir', main_models / 'Lora'), # 💩
-        'DoRA': lambda: resolve_path('lora_dir', main_models / 'Lora'),  # 💩
+        'LORA': lambda: resolve_path('lora_dirs', resolve_path('lora_dir', main_models / 'Lora')),
+        'LoCon': lambda: resolve_path('lora_dirs', resolve_path('lora_dir', main_models / 'Lora')), # 💩
+        'DoRA': lambda: resolve_path('lora_dirs', resolve_path('lora_dir', main_models / 'Lora')),  # 💩
         'VAE': lambda: resolve_path('vae_dir', main_models / 'VAE'),
         'Controlnet': lambda: resolve_path('controlnet_dir', main_models / 'ControlNet'),
         'Poses': lambda: main_models / 'Poses',


### PR DESCRIPTION
## Problem

Forge Neo declares its directory-override args with argparse `action="append"` ([`modules/cmd_args.py:80-83`](https://github.com/Haoming02/sd-webui-forge-classic/blob/neo/modules/cmd_args.py)):

```python
parser.add_argument("--ckpt-dirs",         type=normalized_filepath, action="append", default=[])
parser.add_argument("--lora-dirs",         type=normalized_filepath, action="append", default=[])
parser.add_argument("--text-encoder-dirs", type=normalized_filepath, action="append", default=[])
```

So `cmd_opts.lora_dirs` is a **`list`**, not a `str`. `resolve_path()` in `contenttype_folder()` hands it straight to `Path()`:

```
TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'list'
```

This already affects the `Checkpoint` entry, which references `ckpt_dirs` today.

Separately, `LORA` / `LoCon` / `DoRA` only consult `lora_dir`. Since `lora_dir` always holds a default value, it always wins — so a user launching with `--lora-dirs "G:\LORAS"` gets downloads silently written to `models/Lora` instead of their configured LoRA drive.

## Fix

1. `resolve_path()` unwraps `list`/`tuple` values and takes the first entry.
2. `LORA` / `LoCon` / `DoRA` now check `lora_dirs` before `lora_dir`, mirroring the `ckpt_dir` → `ckpt_dirs` pattern already used on `Checkpoint`.

## Compatibility

The argparse default is `[]`, which is falsy, so the existing `if value` guard still falls through to the fallback when the flag isn't passed. **No behaviour change for users who don't use these flags**, and non-Neo WebUIs (where the attrs are strings or absent) are unaffected — the `isinstance` check simply doesn't fire.

## Verification

Isolated the function and exercised all three states:

| `lora_dirs` | `lora_dir` | result |
|---|---|---|
| `['G:/LORAS']` | `None` | `G:\LORAS` ✅ |
| `[]` (unset default) | `'models/Lora'` | `models\Lora` ✅ |
| `[]` | `None` | `models\Lora` (fallback) ✅ |

And confirmed the pre-fix failure: `Path(['G:/LORAS'])` → `TypeError`.

Full suite still green on `revamp`: **158/158 tests pass**, `scripts/*.py` + `scripts/browser_sources/*.py` compile clean.

Running this locally on Forge Neo with `--lora-dirs "G:\LORAS"`.

## Note on base branch

Targeted at `revamp` since `README_REVAMP.md` states `main` is frozen at v0.9.0 until the revamp merges. The patch applies cleanly to `main` too — happy to retarget or open a second PR if you'd prefer it on both.
